### PR TITLE
Make build strings uniform across CPU and CUDA

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,10 +1,10 @@
 context:
   version: 0.10.2
-  build_number: 0
+  build_number: 1
   use_cuda: ${{ cuda_compiler_version != "None" }}
   pytorch_version: 2.8.0
   vllm_target_device: ${{ "cuda" if use_cuda else "cpu" }}
-  cuda_build_string: cuda_${{ cuda_compiler_version | version_to_buildstring }}
+  cuda_build_string: cuda${{ cuda_compiler_version | version_to_buildstring }}_
   string_prefix: ${{ cuda_build_string if cuda_compiler_version != "None" else "cpu_" }}
   is_cross_compiling: ${{ build_platform != host_platform }}
 


### PR DESCRIPTION
Previously  CPU: cpu_py313h*
           CUDA: cuda_129py313h*

Now         CPU: cpu_py313h*
           CUDA: cuda129_py313h*

This also matches the pattern in pytorch
