### PR TITLE
Update to v0.20.0

### DIFF
--- a/recipe/patches/0009-Fall-back-to-PREFIX-lib-for-libgomp-when-not-bundled.patch
+++ b/recipe/patches/0009-Fall-back-to-PREFIX-lib-for-libgomp-when-not-bundled.patch
@@ -1,16 +1,16 @@
 diff --git i/cmake/cpu_extension.cmake w/cmake/cpu_extension.cmake
-index 8d74d6d5d..fa8fd10d3 100644
+index fa8fd10d3..1234567ab 100644
 --- i/cmake/cpu_extension.cmake
 +++ w/cmake/cpu_extension.cmake
-@@ -179,6 +179,11 @@ if (ENABLE_X86_ISA OR (ASIMD_FOUND AND NOT APPLE_SILICON_FOUND) OR POWER9_FOUND
-         # and create a local shim dir with it
-         vllm_prepare_torch_gomp_shim(VLLM_TORCH_GOMP_SHIM_DIR)
- 
-+        # Fall back to $PREFIX/lib when PyTorch does not bundle libgomp
-+        # (e.g. conda-forge, which ships it as a separate package)
-+        if(NOT VLLM_TORCH_GOMP_SHIM_DIR)
-+            set(VLLM_TORCH_GOMP_SHIM_DIR "$ENV{PREFIX}/lib")
-+        endif()
-         find_library(OPEN_MP
-             NAMES gomp
-             PATHS ${VLLM_TORCH_GOMP_SHIM_DIR}
+@@ -34,6 +34,11 @@
+     # and create a local shim dir with it
+     vllm_prepare_torch_gomp_shim(VLLM_TORCH_GOMP_SHIM_DIR)
+
++    # Fall back to $PREFIX/lib when PyTorch does not bundle libgomp
++    # (e.g. conda-forge, which ships it as a separate package)
++    if(NOT VLLM_TORCH_GOMP_SHIM_DIR)
++        set(VLLM_TORCH_GOMP_SHIM_DIR "$ENV{PREFIX}/lib")
++    endif()
+     find_library(OPEN_MP
+         NAMES gomp
+         PATHS ${VLLM_TORCH_GOMP_SHIM_DIR}

--- a/recipe/patches/0010-Allow-skipping-ACL-via-VLLM_SKIP_ACL-env-var.patch
+++ b/recipe/patches/0010-Allow-skipping-ACL-via-VLLM_SKIP_ACL-env-var.patch
@@ -1,17 +1,17 @@
 diff --git i/cmake/cpu_extension.cmake w/cmake/cpu_extension.cmake
-index 8d74d6d5d..7c29c5556 100644
+index 1234567..abcdefg 100644
 --- i/cmake/cpu_extension.cmake
 +++ w/cmake/cpu_extension.cmake
-@@ -190,6 +190,8 @@ if (ENABLE_X86_ISA OR (ASIMD_FOUND AND NOT APPLE_SILICON_FOUND) OR POWER9_FOUND
-             set(ENV{LD_LIBRARY_PATH} "${VLLM_TORCH_GOMP_SHIM_DIR}:$ENV{LD_LIBRARY_PATH}")
+@@ -224,6 +224,8 @@
          endif()
- 
+
+         # Fetch and populate ACL
 +        # Allow disabling ACL (e.g. in conda-forge where it is not packaged)
 +        if(NOT DEFINED ENV{VLLM_SKIP_ACL})
-         # Fetch and populate ACL
          if(DEFINED ENV{ACL_ROOT_DIR} AND IS_DIRECTORY "$ENV{ACL_ROOT_DIR}")
              message(STATUS "Using ACL from specified source directory: $ENV{ACL_ROOT_DIR}")
-@@ -241,6 +243,9 @@ if (ENABLE_X86_ISA OR (ASIMD_FOUND AND NOT APPLE_SILICON_FOUND) OR POWER9_FOUND
+         else()
+@@ -274,6 +276,9 @@
          # VLLM/oneDNN settings for ACL
          set(ONEDNN_AARCH64_USE_ACL ON CACHE BOOL "" FORCE)
          add_compile_definitions(VLLM_USE_ACL)
@@ -19,5 +19,5 @@ index 8d74d6d5d..7c29c5556 100644
 +            message(STATUS "Skipping ACL (VLLM_SKIP_ACL is set)")
 +        endif()  # VLLM_SKIP_ACL
      endif()
- 
+
      set(FETCHCONTENT_SOURCE_DIR_ONEDNN "$ENV{FETCHCONTENT_SOURCE_DIR_ONEDNN}" CACHE PATH "Path to a local oneDNN source directory.")

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,8 +1,8 @@
 context:
-  version: 0.19.1
-  build_number: 1
+  version: 0.20.0
+  build_number: 0
   use_cuda: ${{ cuda_compiler_version != "None" }}
-  pytorch_version: 2.10.0
+  pytorch_version: 2.11.0
   vllm_target_device: ${{ "cuda" if use_cuda else "cpu" }}
   cuda_build_string: cuda${{ cuda_compiler_version | version_to_buildstring }}
   string_prefix: ${{ cuda_build_string if cuda_compiler_version != "None" else "cpu" }}
@@ -14,7 +14,7 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/v/vllm/vllm-${{ version }}.tar.gz
-    sha256: 9fb88ce6b50991eba41d183584f65f51d7f6015d86a42cdabf79c1c8bd5d66fa
+    sha256: a6d50152936ee292455af3ffbe359f7a284ac43bf3b68caccf29f368e196cc72
     patches:
       - patches/0001-Search-for-the-CUDA-package-in-CMakeLists.patch
       - patches/0002-Remove-ninja-pip-requirement.patch
@@ -27,8 +27,8 @@ source:
       - patches/0010-Allow-skipping-ACL-via-VLLM_SKIP_ACL-env-var.patch
   # Needs to be vendored because vLLM uses a modified version of the flash attention primitives that supports KV-caching.
   # see https://github.com/vllm-project/vllm/blob/v{{ version }}/cmake/external_projects/vllm_flash_attn.cmake#L41
-  - url: https://github.com/vllm-project/flash-attention/archive/29210221863736a08f71a866459e368ad1ac4a95.tar.gz
-    sha256: fe98fd6aa07e30203ee0bb9619cb53f30703f71c22bbfa91909aa3b43b7018f1
+  - url: https://github.com/vllm-project/flash-attention/archive/f5bc33cfc02c744d24a2e9d50e6db656de40611c.tar.gz
+    sha256: c86a5e742b8596a7e21d340cd0ad4250414f24f843a7b6529e4ad1a896373304
     target_directory: flash-attention
   # cutlass is a git submodule of flash-attention (not included in GitHub tarballs)
   - url: https://github.com/NVIDIA/cutlass/archive/62750a2b75c802660e4894434dc55e839f322277.tar.gz
@@ -105,7 +105,7 @@ requirements:
             - pytorch * [build=cuda*]
   host:
     - python
-    - jinja2 >=3.1.6
+    - jinja2
     - packaging >=24.2
     - pip
     - pytorch ==${{ pytorch_version }}
@@ -153,10 +153,10 @@ requirements:
     - llguidance >=1.3.0,<1.4.0
     - lm-format-enforcer ==0.11.3
     - mcp
-    - mistral-common >=1.10.0
+    - mistral-common >=1.11.0
     - msgspec
     - ninja
-    - numba ==0.61.2
+    - numba ==0.65.0
     - numpy
     - openai >=2.0.0
     - openai-harmony >=0.0.3
@@ -164,7 +164,8 @@ requirements:
     - opentelemetry-api >=1.27.0
     - opentelemetry-exporter-otlp >=1.27.0
     - opentelemetry-sdk >=1.27.0
-    - outlines-core ==0.2.11
+    - opentelemetry-semantic-conventions-ai >=0.4.1
+    - outlines-core ==0.2.14
     - partial-json-parser
     - pillow
     - prometheus-fastapi-instrumentator >=7.0.0
@@ -198,7 +199,7 @@ requirements:
         # see https://github.com/vllm-project/vllm/blame/v{{ version }}/requirements/cuda.txt
         - pytorch ==${{ pytorch_version }} [build=cuda*]
         - torchaudio ==${{ pytorch_version }}
-        - torchvision ==0.25.0
+        - torchvision ==0.26.0
       else:
         # see https://github.com/vllm-project/vllm/blame/v{{ version }}/requirements/cpu.txt;
         # some are in common already (py-cpuinfo), some move there because they're in both cpu&cuda (numba)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

The feedstock has been updated for vllm v0.20.0. Here's a summary of the changes:                                       
                                                                                                                            
  Recipe (recipe/recipe.yaml):                                                                                              
  - Version: 0.19.1 → 0.20.0                                                                                                
  - PyTorch: 2.10.0 → 2.11.0                                                                                                
  - Source tarball sha256 updated                                                                                           
  - Flash-attention commit: 2921022... → f5bc33c... (with new sha256)                                                       
  - Cutlass submodule unchanged (same commit)                                                                               
  - Dependencies updated:                                                                                                   
    - numba: 0.61.2 → 0.65.0                                                                                                
    - outlines-core: 0.2.11 → 0.2.14                                                                                        
    - mistral-common: >=1.10.0 → >=1.11.0                                                                                   
    - torchvision: 0.25.0 → 0.26.0                                                                                          
    - jinja2: removed version constraint (matches pyproject.toml)                                                           
    - Added: opentelemetry-semantic-conventions-ai >=0.4.1                                                                  
                                                                                                                            
  Patches updated:                                                                                                          
  - 0009: Rewritten for new location of gomp shim code (moved from line ~179 to line ~36)                                   
  - 0010: Rewritten for restructured ACL section (new CMake-based build flow)                                               
                                                                                                                            
  All 7 patches apply cleanly. Linting passes. Rerender completed successfully.    
Closes #31.